### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,34 +6,34 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Sodaq_WifiBee		KEYWORD1
+Sodaq_WifiBee	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init			KEYWORD2
+init	KEYWORD2
 connectionSettings	KEYWORD2
-setDiag			KEYWORD2
-getDeviceType		KEYWORD2
-on			KEYWORD2
-off			KEYWORD2
+setDiag	KEYWORD2
+getDeviceType	KEYWORD2
+on	KEYWORD2
+off	KEYWORD2
 
-HTTPGet			KEYWORD2
-HTTPPost		KEYWORD2
-HTTPPut			KEYWORD2
+HTTPGet	KEYWORD2
+HTTPPost	KEYWORD2
+HTTPPut	KEYWORD2
 
-opentTCP		KEYWORD2
-sendTCPAscii		KEYWORD2
-sendTCPBinary		KEYWORD2
-closeTCP		KEYWORD2
+opentTCP	KEYWORD2
+sendTCPAscii	KEYWORD2
+sendTCPBinary	KEYWORD2
+closeTCP	KEYWORD2
 
-openUDP			KEYWORD2
-sendUDPAscii 		KEYWORD2
-sendUDPBinary		KEYWORD2
-closeUDP		KEYWORD2
+openUDP	KEYWORD2
+sendUDPAscii	KEYWORD2
+sendUDPBinary	KEYWORD2
+closeUDP	KEYWORD2
 
-readResponseAscii 	KEYWORD2
+readResponseAscii	KEYWORD2
 readResponseBinary	KEYWORD2
 readHTTPResponse	KEYWORD2
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords